### PR TITLE
Update playbook for Mli Forever host

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -77,8 +77,8 @@
         lineinfile: dest=/etc/hosts line="192.168.254.123 logfaces"
       - name: Add logfaces-boston to hostfile
         lineinfile: dest=/etc/hosts line="192.168.100.124 logfaces-boston"
-      - name: Add mli_forever to hostfile
-        lineinfile: dest=/etc/hosts line="192.168.254.66 mli_forever"
+      - name: Add mli-forever to hostfile
+        lineinfile: dest=/etc/hosts line="192.168.254.66 mli-forever"
       - name: Add mongo1test to hostfile
         lineinfile: dest=/etc/hosts line="192.168.254.57 mongo1test"
       - name: Add mongo2test to hostfile


### PR DESCRIPTION
Updated Playbook to use a - instead of a _ for the Mli Forever Host.
